### PR TITLE
Update STATICFILES_DIRS path in base.py

### DIFF
--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -147,7 +147,7 @@ WSGI_APPLICATION = "config.wsgi.application"
 STATIC_URL = "/static/"
 STATIC_ROOT = config("STATIC_ROOT", default=os.path.join(BASE_DIR, "/data/staticfiles"))
 
-STATICFILES_DIRS = (os.path.join(BASE_DIR, "config", "static"),)
+STATICFILES_DIRS = (os.path.join(BASE_DIR, "static"),)
 
 MEDIA_URL = '/media/'
 MEDIA_ROOT = config('MEDIA_ROOT', default=os.path.join(BASE_DIR, '/data/media'))


### PR DESCRIPTION
Fix for the warning:


WARNINGS:
?: (staticfiles.W004) The directory '/opt/project/src/config/config/static' in the STATICFILES_DIRS setting does not exist.